### PR TITLE
Add hybrid timing offset compensation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ pilot_spacing: 2
 pilot_symbols: [1,12]
 freq_offset: 0.02
 timing_offset: 100
-est_time: fft_ml  #fft_ml/diff_phase
+est_time: fft_ml  #fft_ml/diff_phase/ml_then_phase
 channel_type: awgn  #awgn/multipath/rayleigh
 display_est_result: true
 interp_method: linear  # linear or nearest

--- a/experiments/run_experiments.py
+++ b/experiments/run_experiments.py
@@ -65,7 +65,7 @@ def main():
     cfg = load_config(config_path)
     snr_db_list = np.arange(0, 31, 2)
     num_trials = 200  # 每个SNR点的仿真次数
-    to_methods = ['fft_ml', 'diff_phase']
+    to_methods = ['fft_ml', 'diff_phase', 'ml_then_phase']
     
     # 创建结果目录
     results_dir = Path(__file__).parent.parent / "results"

--- a/src/config.py
+++ b/src/config.py
@@ -35,7 +35,7 @@ class OFDMConfig:
     est_method: str = 'linear'         # 信道估计方法：'linear'（线性插值）或'ls'（最小二乘）
     interp_method: str = 'linear'      # 信道插值方式：'linear'或'nearest'
     equalizer: str = 'zf'              # 均衡器类型：'zf'（零强制）或'mmse'（最小均方误差）
-    est_time: str = 'fft_ml'           # 定时偏移估计方法：'fft_ml'（FFT最大似然）或'diff_phase'（相位差）
+    est_time: str = 'fft_ml'           # 定时偏移估计方法：'fft_ml'（FFT最大似然）/'diff_phase'（相位差）或'ml_then_phase'（两步法）
     # 同步配置
     sync_method: str = 'auto'          # 同步方法：'auto'（自动）或'manual'（手动）
     freq_offset: float = 0.0           # 初始频偏估计值


### PR DESCRIPTION
## Summary
- abstract timing offset compensation into `compensate_timing_offset`
- add hybrid `ml_then_phase` option combining FFT‑ML and phase difference methods
- expose new option in configuration and experiments

## Testing
- `python test/test.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68490da7b5688322aec388ac739d2490