### PR TITLE
Add multi-antenna receiver support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,7 @@ mod_order: 6  # QPSK
 num_symbols: 14
 snr_db: 15
 n_subcarrier: 3276
+num_rx_ant: 1
 pilot_pattern: comb
 pilot_spacing: 2
 pilot_symbols: [1,12]

--- a/experiments/run_experiments.py
+++ b/experiments/run_experiments.py
@@ -45,9 +45,9 @@ def run_single_experiment(snr_db: float, cfg: OFDMConfig) -> float:
     
     # 信道传输
     if cfg.channel_type == "awgn":
-        rx_signal = awgn_channel(tx_signal, snr_db)
+        rx_signal = awgn_channel(tx_signal, snr_db, num_rx=cfg.num_rx_ant)
     else:
-        rx_signal, _ = multipath_channel(tx_signal, snr_db)
+        rx_signal, _ = multipath_channel(tx_signal, snr_db, num_rx=cfg.num_rx_ant)
     phase_rotation = 2 * np.pi * cfg.freq_offset * np.arange(len(rx_signal)) / cfg.n_fft
     rx_signal = rx_signal * np.exp(1j * phase_rotation)
     rx_signal = np.roll(rx_signal, cfg.timing_offset)

--- a/src/config.py
+++ b/src/config.py
@@ -22,6 +22,7 @@ class OFDMConfig:
     n_subcarrier: int = 3276           # 子载波数量
     mod_order: int = 4                 # 调制阶数（2:QPSK, 4:16QAM, 6:64QAM）
     num_symbols: int = 100             # OFDM符号数量
+    num_rx_ant: int = 1               # 接收天线数量
     
     # 导频配置
     pilot_pattern: str = 'comb'        # 导频图案类型：'comb'（梳状）或'block'（块状）
@@ -52,6 +53,8 @@ class OFDMConfig:
             raise ValueError("调制阶数必须是2、4或6")
         if self.num_symbols <= 0:
             raise ValueError("OFDM符号数量必须大于0")
+        if self.num_rx_ant <= 0:
+            raise ValueError("接收天线数量必须大于0")
             
         # 验证导频配置
         if self.pilot_pattern not in ['comb', 'block']:

--- a/test/test.py
+++ b/test/test.py
@@ -79,9 +79,16 @@ class TestOFDMSystem(unittest.TestCase):
             )
         else:
             raise ValueError(f"不支持的信道类型: {self.cfg.channel_type}")
-        phase_rotation = 2 * np.pi * self.cfg.freq_offset * np.arange(len(rx_signal)) / self.cfg.n_fft
-        rx_signal = rx_signal * np.exp(1j * phase_rotation)
-        rx_signal = np.roll(rx_signal, self.cfg.timing_offset)
+        time_len = rx_signal.shape[-1]
+        phase_rotation = (
+            2 * np.pi * self.cfg.freq_offset * np.arange(time_len) / self.cfg.n_fft
+        )
+        if rx_signal.ndim == 1:
+            rx_signal = rx_signal * np.exp(1j * phase_rotation)
+            rx_signal = np.roll(rx_signal, self.cfg.timing_offset)
+        else:
+            rx_signal = rx_signal * np.exp(1j * phase_rotation)[None, :]
+            rx_signal = np.roll(rx_signal, self.cfg.timing_offset, axis=-1)
         # 接收端处理
         rx_syms, rx_bits = ofdm_rx(rx_signal, self.cfg)
         # 计算误码率

--- a/test/test.py
+++ b/test/test.py
@@ -68,11 +68,15 @@ class TestOFDMSystem(unittest.TestCase):
         
         # 添加噪声
         if self.cfg.channel_type == 'multipath':
-            rx_signal,h_channel = multipath_channel(tx_signal, self.cfg.snr_db)   
+            rx_signal, h_channel = multipath_channel(
+                tx_signal, self.cfg.snr_db, num_rx=self.cfg.num_rx_ant
+            )
         elif self.cfg.channel_type == 'awgn':
-            rx_signal = awgn_channel(tx_signal, self.cfg.snr_db)
+            rx_signal = awgn_channel(tx_signal, self.cfg.snr_db, num_rx=self.cfg.num_rx_ant)
         elif self.cfg.channel_type == 'rayleigh':
-            rx_signal,h_channel = rayleigh_channel(tx_signal, self.cfg.snr_db)
+            rx_signal, h_channel = rayleigh_channel(
+                tx_signal, self.cfg.snr_db, num_rx=self.cfg.num_rx_ant
+            )
         else:
             raise ValueError(f"不支持的信道类型: {self.cfg.channel_type}")
         phase_rotation = 2 * np.pi * self.cfg.freq_offset * np.arange(len(rx_signal)) / self.cfg.n_fft
@@ -116,9 +120,19 @@ class TestOFDMSystem(unittest.TestCase):
         # 生成测试信号
         tx = np.random.randn(1000) + 1j * np.random.randn(1000)
         snr_db_target = 20
-        rx, h = multipath_channel(tx, snr_db_target)
+        rx, h = multipath_channel(tx, snr_db_target, num_rx=self.cfg.num_rx_ant)
         meas_snr = np.mean(np.abs(np.convolve(tx, h,'same'))**2) / np.mean(np.abs(rx - np.convolve(tx,h,'same'))**2)
         print(10*np.log10(meas_snr))   # 应接近 20 dB
+
+    def test_multi_antenna_reception(self):
+        """测试多天线接收流程"""
+        self.cfg.num_rx_ant = 4
+        total_bits = self.cfg.get_total_bits()
+        bits = np.random.randint(0, 2, total_bits)
+        tx_signal, _ = ofdm_tx(bits, self.cfg)
+        rx_signal = awgn_channel(tx_signal, self.cfg.snr_db, num_rx=self.cfg.num_rx_ant)
+        _, rx_bits = ofdm_rx(rx_signal, self.cfg)
+        self.assertEqual(len(rx_bits), len(bits))
 
 
     def test_ofdm_rx_with_channel_estimation(self):
@@ -135,7 +149,9 @@ class TestOFDMSystem(unittest.TestCase):
         snr_db = 0
         #计算噪声线性值
         noise_var = 10 ** (-snr_db / 10)
-        rx_signal,h_channel = multipath_channel(time_signal, snr_db)   
+        rx_signal, h_channel = multipath_channel(
+            time_signal, snr_db, num_rx=self.cfg.num_rx_ant
+        )
 
         # 移除CP并进行FFT
         rx_symbols_freq_offset = remove_cp_and_fft(rx_signal, self.cfg)
@@ -155,10 +171,4 @@ class TestOFDMSystem(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    # 创建测试套件
-    suite = unittest.TestSuite()
-    # 只添加信道估计测试
-    suite.addTest(TestOFDMSystem('test_ofdm_tx_rx'))
-    # 运行测试
-    runner = unittest.TextTestRunner()
-    runner.run(suite)
+    unittest.main()

--- a/txt/test.py
+++ b/txt/test.py
@@ -69,9 +69,16 @@ class TestOFDMSystem(unittest.TestCase):
         # 添加噪声
         # rx_signal,h_channel = multipath_channel(tx_signal, self.cfg.snr_db)   
         rx_signal = awgn_channel(tx_signal, self.cfg.snr_db)
-        phase_rotation = 2 * np.pi * self.cfg.freq_offset * np.arange(len(rx_signal)) / self.cfg.n_fft
-        rx_signal = rx_signal * np.exp(1j * phase_rotation)
-        rx_signal = np.roll(rx_signal, self.cfg.timing_offset)
+        time_len = rx_signal.shape[-1]
+        phase_rotation = (
+            2 * np.pi * self.cfg.freq_offset * np.arange(time_len) / self.cfg.n_fft
+        )
+        if rx_signal.ndim == 1:
+            rx_signal = rx_signal * np.exp(1j * phase_rotation)
+            rx_signal = np.roll(rx_signal, self.cfg.timing_offset)
+        else:
+            rx_signal = rx_signal * np.exp(1j * phase_rotation)[None, :]
+            rx_signal = np.roll(rx_signal, self.cfg.timing_offset, axis=-1)
         # 接收端处理
         rx_syms, rx_bits = ofdm_rx(rx_signal, self.cfg)
         # 计算误码率


### PR DESCRIPTION
## Summary
- extend configuration with `num_rx_ant`
- implement multi-antenna versions of AWGN, Rayleigh and multipath channels
- update receiver processing to combine multiple antennas
- adjust utilities and tests for new parameter
- add a new unit test covering multi-antenna reception

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python test/test.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_684916a7705c83228ff10d879fc62084