### PR TITLE
Add LDPC FEC module

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ num_symbols: 14
 snr_db: 15
 n_subcarrier: 3276
 num_rx_ant: 1
+code_rate: 0.5
 pilot_pattern: comb
 pilot_spacing: 2
 pilot_symbols: [1,12]

--- a/src/config.py
+++ b/src/config.py
@@ -23,6 +23,7 @@ class OFDMConfig:
     mod_order: int = 4                 # 调制阶数（2:QPSK, 4:16QAM, 6:64QAM）
     num_symbols: int = 100             # OFDM符号数量
     num_rx_ant: int = 1               # 接收天线数量
+    code_rate: float = 1.0             # 信道编码码率 (0<rate<=1)
     
     # 导频配置
     pilot_pattern: str = 'comb'        # 导频图案类型：'comb'（梳状）或'block'（块状）
@@ -55,6 +56,8 @@ class OFDMConfig:
             raise ValueError("OFDM符号数量必须大于0")
         if self.num_rx_ant <= 0:
             raise ValueError("接收天线数量必须大于0")
+        if not (0 < self.code_rate <= 1):
+            raise ValueError("code_rate 必须在0到1之间")
             
         # 验证导频配置
         if self.pilot_pattern not in ['comb', 'block']:

--- a/src/fec.py
+++ b/src/fec.py
@@ -1,0 +1,120 @@
+"""
+Forward Error Correction (FEC) utilities using Sionna's LDPC implementation.
+
+该模块提供基于 Sionna 0.19.2 的 LDPC 信道编码和译码封装，支持根
+据码率自动计算信息比特数，并在需要时进行分段处理。
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List
+
+import numpy as np
+
+try:
+    from sionna.fec.ldpc.encoding import LDPC5GEncoder
+    from sionna.fec.ldpc.decoding import LDPC5GDecoder
+except ImportError as exc:  # pragma: no cover - library may be missing
+    raise ImportError(
+        "Sionna 0.19.2 is required for LDPC operations"
+    ) from exc
+
+from .config import OFDMConfig
+
+# 3GPP NR LDPC 最大信息比特数
+MAX_LDPC_K = 8448
+# 3GPP NR LDPC 最大码字长度 (来自 Sionna 限制)
+MAX_LDPC_N = 316 * 384
+
+
+def compute_k(cfg: OFDMConfig, rate: float) -> int:
+    """根据码率计算信息比特数"""
+    total_bits = cfg.get_total_bits()
+    return int(total_bits * rate)
+
+
+def _segment_information(bits: np.ndarray, segment_length: int) -> List[np.ndarray]:
+    """将信息比特按照给定长度分段"""
+    segments = []
+    start = 0
+    while start < len(bits):
+        end = min(start + segment_length, bits.size)
+        segments.append(bits[start:end])
+        start = end
+    return segments
+
+
+def ldpc_encode(bits: np.ndarray, cfg: OFDMConfig, rate: float) -> List[np.ndarray]:
+    """按需分段的 LDPC 编码
+
+    参数``bits``长度应等于 ``compute_k(cfg, rate)``，编码后总长度与
+    ``cfg.get_total_bits()`` 一致。若信息比特数超过 ``MAX_LDPC_K``，
+    会自动将其平均分段。
+    """
+
+    k_total = compute_k(cfg, rate)
+    n_total = cfg.get_total_bits()
+    if bits.size != k_total:
+        raise ValueError(f"输入比特数应为{k_total}, 实际为{bits.size}")
+
+    if k_total <= MAX_LDPC_K and n_total <= MAX_LDPC_N:
+        encoder = LDPC5GEncoder(k_total, n_total)
+        coded = encoder(bits[None, :].astype("float32")).numpy().squeeze()
+        return [coded]
+
+    num_segments = math.ceil(k_total / MAX_LDPC_K)
+
+    base_k = k_total // num_segments
+    k_segments = [base_k + (1 if i < k_total % num_segments else 0)
+                  for i in range(num_segments)]
+
+    base_n = n_total // num_segments
+    n_segments = [base_n + (1 if i < n_total % num_segments else 0)
+                  for i in range(num_segments)]
+
+    encoded_segments = []
+    start = 0
+    for k_seg, n_seg in zip(k_segments, n_segments):
+        seg_bits = bits[start:start + k_seg]
+        start += k_seg
+        encoder = LDPC5GEncoder(k_seg, n_seg)
+        coded = encoder(seg_bits[None, :].astype("float32")).numpy().squeeze()
+        encoded_segments.append(coded)
+
+    return encoded_segments
+
+
+def ldpc_decode(
+    llrs: List[np.ndarray],
+    cfg: OFDMConfig,
+    rate: float,
+    *,
+    num_iter: int = 6,
+) -> np.ndarray:
+    """对应 :func:`ldpc_encode` 的分段译码"""
+
+    k_total = compute_k(cfg, rate)
+
+    decoded_list = []
+    for llr in llrs:
+        n_seg = llr.size
+        k_seg = int(round(n_seg * rate))
+        encoder = LDPC5GEncoder(k_seg, n_seg)
+        decoder = LDPC5GDecoder(encoder, hard_out=True, num_iter=num_iter)
+        decoded = decoder(llr[None, :].astype("float32")).numpy().squeeze()
+        decoded_list.append(decoded.astype(np.int8))
+
+    decoded_bits = np.concatenate(decoded_list)[:k_total]
+    return decoded_bits
+
+
+if __name__ == "__main__":  # 简单测试
+    cfg = OFDMConfig()
+    r = 0.5
+    k = compute_k(cfg, r)
+    test_bits = np.random.randint(0, 2, k)
+    cbs = ldpc_encode(test_bits, cfg, r)
+    noisy_llrs = [1 - 2 * cb for cb in cbs]
+    dec = ldpc_decode(noisy_llrs, cfg, r)
+    print(f"比特是否一致: {np.all(dec == test_bits)}")


### PR DESCRIPTION
## Summary
- add LDPC FEC utilities and segmentation logic
- allow configurable `code_rate` in `OFDMConfig`
- extend default YAML config with `code_rate`
- add LDPC end-to-end test
- support soft-output demodulation and use it in tests

## Testing
- `pytest -q` *(no tests discovered)*
- `pytest test/test.py::TestOFDMSystem::test_ofdm_tx_rx_ldpc -q`
- `python test/test.py` *(fails: insert_pilots signature mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684a700adb9c8322b74e01d9e9fd9902