### PR TITLE
Fix AWGN noise power and normalize OFDM FFTs

### DIFF
--- a/src/channel.py
+++ b/src/channel.py
@@ -27,11 +27,9 @@ def awgn_channel(signal: np.ndarray, snr_db: float, num_rx: int = 1) -> np.ndarr
     Returns:
         经过AWGN信道的信号
     """
-    # 计算信号功率
-    signal_power = np.mean(np.abs(signal) ** 2)
-    
-    # 计算噪声功率
-    noise_power = signal_power / (10 ** (snr_db / 10))
+    # 噪声功率按单位平均功率信号定义，避免随输入幅度变化
+    snr_lin = 10 ** (snr_db / 10)
+    noise_power = 1 / snr_lin
     
     # 生成复高斯噪声
     if num_rx == 1:

--- a/src/ofdm_rx.py
+++ b/src/ofdm_rx.py
@@ -501,7 +501,7 @@ def remove_cp_and_fft(signal: np.ndarray, cfg: OFDMConfig) -> np.ndarray:
             start_idx = i * symbol_len + cfg.cp_len
             end_idx = start_idx + cfg.n_fft
             time_symbol = signal[start_idx:end_idx]
-            rx_symbols[i] = np.fft.fft(time_symbol, cfg.n_fft)
+            rx_symbols[i] = np.fft.fft(time_symbol, cfg.n_fft) / np.sqrt(cfg.n_fft)
         return rx_symbols[:, subcarrier_indices]
     elif signal.ndim == 2:
         num_ant, total_len = signal.shape
@@ -512,7 +512,7 @@ def remove_cp_and_fft(signal: np.ndarray, cfg: OFDMConfig) -> np.ndarray:
                 start_idx = i * symbol_len + cfg.cp_len
                 end_idx = start_idx + cfg.n_fft
                 time_symbol = signal[ant, start_idx:end_idx]
-                rx_symbols[ant, i] = np.fft.fft(time_symbol, cfg.n_fft)
+                rx_symbols[ant, i] = np.fft.fft(time_symbol, cfg.n_fft) / np.sqrt(cfg.n_fft)
         return rx_symbols[..., subcarrier_indices]
     else:
         raise ValueError("signal维度必须为1或2")

--- a/src/ofdm_tx.py
+++ b/src/ofdm_tx.py
@@ -155,8 +155,8 @@ def ofdm_tx(bits: np.ndarray, cfg: OFDMConfig) -> Tuple[np.ndarray, np.ndarray]:
         # 保存频域符号
         freq_symbols[i] = ofdm_symbol
         
-        # IFFT
-        time_symbol = np.fft.ifft(ofdm_symbol, cfg.n_fft)
+        # IFFT，乘以 sqrt(N) 使得时域/频域能量一致
+        time_symbol = np.fft.ifft(ofdm_symbol, cfg.n_fft) * np.sqrt(cfg.n_fft)
         
         # 添加循环前缀
         cp = time_symbol[-cfg.cp_len:]
@@ -164,7 +164,12 @@ def ofdm_tx(bits: np.ndarray, cfg: OFDMConfig) -> Tuple[np.ndarray, np.ndarray]:
         
         # 添加到总信号
         time_signal = np.concatenate([time_signal, time_symbol])
-    
+
+    # 时域信号功率归一化
+    power = np.mean(np.abs(time_signal) ** 2)
+    if power > 0:
+        time_signal = time_signal / np.sqrt(power)
+
     return time_signal, freq_symbols
 
 def plot_ofdm_symbol(ofdm_symbol: np.ndarray, pilot_indices: np.ndarray, 


### PR DESCRIPTION
## Summary
- avoid scaling AWGN noise with the input signal power
- apply √N scaling to OFDM IFFT/FFT for energy consistency
- normalize the time-domain signal to unit power

## Testing
- `ruff check --quiet` *(fails: E402 import order, F401 unused imports)*
- `mypy src` *(fails: missing stubs for numpy.typing and sionna)*
- `pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_684b83f2f744832292087a3387894a0f