### PR TITLE
Add multi-transmit support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ num_symbols: 14
 snr_db: 10
 n_subcarrier: 1536
 num_rx_ant: 2
+num_tx_ant: 1
 code_rate: 1 # 1 for no FEC, float for FEC
 pilot_pattern: comb
 pilot_spacing: 2
@@ -18,3 +19,4 @@ display_est_result: False  # 是否显示估计结果
 interp_method: linear  # linear or nearest
 equ_method: mrc  # mmse/mrc/irc
 win_size: [8,1,2]  # QPSK窗口大小（用于信道估计）
+

--- a/src/config.py
+++ b/src/config.py
@@ -26,6 +26,7 @@ class OFDMConfig:
     mod_order: int = 4                 # 调制阶数（2:QPSK, 4:16QAM, 6:64QAM）
     num_symbols: int = 14             # OFDM符号数量
     num_rx_ant: int = 1               # 接收天线数量
+    num_tx_ant: int = 1               # 发射天线数量
     code_rate: float = 0.5             # 信道编码码率 (0<rate<=1)
     
     # 导频配置
@@ -61,6 +62,8 @@ class OFDMConfig:
             raise ValueError("OFDM符号数量必须大于0")
         if self.num_rx_ant <= 0:
             raise ValueError("接收天线数量必须大于0")
+        if self.num_tx_ant <= 0:
+            raise ValueError("发射天线数量必须大于0")
         if not (0 < self.code_rate <= 1):
             raise ValueError("code_rate 必须在0到1之间")
             
@@ -244,7 +247,7 @@ class OFDMConfig:
         Returns:
             总比特数
         """
-        return self.get_num_data_carriers() * self.mod_order
+        return self.get_num_data_carriers() * self.mod_order * self.num_tx_ant
     
     def get_total_bits(self) -> int:
         """获取整个传输的总比特数
@@ -252,14 +255,19 @@ class OFDMConfig:
         Returns:
             总比特数
         """
-        return self.get_total_bits_per_symbol()*len(self.get_data_symbol_indices())
+        return (
+            self.get_total_bits_per_symbol()
+            * len(self.get_data_symbol_indices())
+        )
 
 def load_config(config_path: str) -> OFDMConfig:
     """从YAML文件加载配置"""
     with open(config_path, 'r', encoding='utf-8') as f:
         config_dict = yaml.safe_load(f)
-    return OFDMConfig(**config_dict) 
+    if 'num_tx_ant' not in config_dict:
+        config_dict['num_tx_ant'] = 1
+    return OFDMConfig(**config_dict)
 
 if __name__ == '__main__':
-    cfg = load_config(r'.\config.yaml')
+    cfg = load_config('./config.yaml')
     print(cfg.num_symbols)

--- a/tests/test.py
+++ b/tests/test.py
@@ -9,6 +9,7 @@ import numpy as np
 import sys
 from pathlib import Path
 import matplotlib.pyplot as plt
+import yaml
 
 # 添加项目根目录到Python路径
 project_root = str(Path(__file__).parent.parent)
@@ -204,6 +205,23 @@ class TestOFDMSystem(unittest.TestCase):
         print(f"信道估计结果: {h_est}")
 
 
+class TestNumTxAnt(unittest.TestCase):
+    def test_single_stream(self):
+        cfg = load_config('config.yaml')
+        self.assertEqual(cfg.num_tx_ant, 1)
+        expected = cfg.get_num_data_carriers() * cfg.mod_order * cfg.num_tx_ant
+        self.assertEqual(cfg.get_total_bits_per_symbol(), expected)
+
+    def test_two_streams(self):
+        with open('config.yaml', 'r', encoding='utf-8') as f:
+            cfg_dict = yaml.safe_load(f)
+        cfg_dict['num_tx_ant'] = 2
+        cfg = OFDMConfig(**cfg_dict)
+        expected = cfg.get_num_data_carriers() * cfg.mod_order * cfg.num_tx_ant
+        self.assertEqual(cfg.num_tx_ant, 2)
+        self.assertEqual(cfg.get_total_bits_per_symbol(), expected)
+
+
 if __name__ == '__main__':
     # 创建测试套件
     # unittest.main()
@@ -213,3 +231,4 @@ if __name__ == '__main__':
     # 运行测试
     runner = unittest.TextTestRunner()
     runner.run(suite)
+


### PR DESCRIPTION
## Summary
- support configuration of multiple transmit antennas
- validate new field in `OFDMConfig`
- compute bit counts using new `num_tx_ant` value
- expose `num_tx_ant` in config loader and default yaml
- test parsing and calculations for multi-stream use

## Testing
- `pytest -q tests/test.py::TestNumTxAnt::test_single_stream tests/test.py::TestNumTxAnt::test_two_streams`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853b795c6f883229ff474cab8ce43df